### PR TITLE
fix commands in hadoop_in_gcp.md

### DIFF
--- a/hadoop/hadoop_in_gcp.md
+++ b/hadoop/hadoop_in_gcp.md
@@ -61,7 +61,7 @@ git clone https://github.com/singhj/big-data-repo.git
 
 ## Moving Files to HDFS
 
-To move files on Cluster Master, into HDFS, use `hadoop fs -put ~/big-data-repo/five-books /user/singhj` 
+To move files on Cluster Master, into HDFS, use `hadoop fs -put ~/big-data-repo/five-books /user/singhj/five-books` 
 
     hadoop fs -mkdir  /user/singhj/five-books            # create directory five-books in HDFS
     hadoop fs -put five-books/* /user/singhj/five-books  # put the contents of five-books into HDFS
@@ -84,7 +84,7 @@ The objective of this step is to verify that we have a good installation of `had
 
 The command is
 
-    hadoop jar /usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar wordcount five-books /books-count
+    hadoop jar /usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar wordcount /user/singhj/five-books /books-count
 
 Hadoop uses hdfs as its (distributed) file system. The directory /books-count is created by the above command and must not already exist!
 


### PR DESCRIPTION
**Issue**: Not able to verify files in HDFS with command `hadoop fs -ls /user/singhj/five-books` due to typo in the `hadoop fs -put` command.
Fixed command (file path) in the **Moving Files to HDFS section**.

From 
`hadoop fs -put ~/big-data-repo/five-books /user/singhj`
To
`hadoop fs -put ~/big-data-repo/five-books /user/singhj/five-books`

**Issue**: Input file path should aligned with previous commands.
Fixed input file path in the **Running the pre-packaged Hadoop Wordcount section** for hadoop run.
From 
`hadoop jar /usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar wordcount five-books /books-count`
To
`hadoop jar /usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar wordcount /user/singhj/five-books /books-count`

